### PR TITLE
Switch to organizeDeclarations and specify some methods

### DIFF
--- a/resources/config.swiftformat
+++ b/resources/config.swiftformat
@@ -22,6 +22,7 @@
 --structthreshold 20 # organizeDeclarations
 --enumthreshold 20 # organizeDeclarations
 --organizetypes class,struct,enum,extension # organizeDeclarations
+--lifecycle viewDidLoad viewWillAppear viewDidAppear viewDidLayoutSubviews traitCollectionDidChange options # organizeDeclarations
 --extensionacl on-declarations # extensionAccessControl
 --patternlet inline # hoistPatternLet
 --redundanttype inferred # redundantType
@@ -49,7 +50,7 @@
 --rules redundantFileprivate
 --rules redundantRawValues
 --rules sortedImports
---rules sortDeclarations
+--rules organizeDeclarations
 --rules strongifiedSelf
 --rules trailingCommas
 --rules trailingSpace


### PR DESCRIPTION
We can move to `sortDeclarations` when it gets out of beta, if we want to. This also gets more specific about `organizeDeclarations`.